### PR TITLE
把hackfoldr的超連結中的pidandoufou拿掉

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div class="grid-item"><h1>群島🏝archipiélago</h1></div>
     <div class="grid-item"><img src="images/archipelago-3-01.png" /></div>
     <div class="grid-item"><a href="//facebook.com/archipielagoTW" target="_blank">We use Facebook to advertise</a></div>
-    <div class="grid-item"><a href="//beta.hackfoldr.org/pidandoufou" target="_blank">We use Hackfoldr to organize</a></div>
+    <div class="grid-item"><a href="//beta.hackfoldr.org/" target="_blank">We use Hackfoldr to organize</a></div>
     <div class="grid-item"><a href="//github.com/chihaoyo/archipielago" target="_blank">Send us a PR via GitHub</a></div>
     <!--<div class="grid-item large"><script src="https://gist.github.com/chihaoyo/6db79f23fcbdc542947f4ee9857335e6.js"></script></div>-->
   </section>


### PR DESCRIPTION
由於hackfoldr中有許多共做的文件，如年度共筆、帳冊、物資記錄等
在思考我們的hackfoldr是否有要直接公開在網路上？還是限開放給親朋好友？

在想網站的連結可以放beta.hackfoldr.org就好，有來過的人可以用歷史連結連到
沒來過的親朋好友我們可以再給他們pidandoufou密語